### PR TITLE
modified endpoints and advance_endpoints so that REGBRIDGE_OFFSET end…

### DIFF
--- a/python/src/interfaces/interfaces.py
+++ b/python/src/interfaces/interfaces.py
@@ -180,6 +180,7 @@ class Endpoint:
             remaining_name = remaining_name.replace('_GEN_ADDR', '')
             # If the remaining name is shorter it is because GEN_ADDR was replaced
             gen_address = len(remaining_name) < previous_len
+
             # Endpoint name
             ep_name = remaining_name
             if ep_name == 'NUM_OUTGOING_EPS':


### PR DESCRIPTION
…points do not roll over

The "roll over" feature of `advance_endpoints` was acting on REGBRIDGE_OFFSET bit indices when it should not.
REGBRIDGE_OFFSET bit indices should always advance with the chip number independent of the MAX_WIDTH. 

Modifications:

- Add a `regbridge` boolean to the Endpoint class that detects if _REGBRIDGE_OFFSET_ is in the endpoint name. 
- in `advance_endpoints` check for `not endpoint.regbridge` before "rolling over" the `bit_index_low` and the `bit_index_high`.
- Note that the endpoint address is irrelevant to how we right to the register bridge.